### PR TITLE
Fixing #9 "title" instead of "fullName" in .jest-test-results.json

### DIFF
--- a/src/components/TestsPanel.js
+++ b/src/components/TestsPanel.js
@@ -105,7 +105,7 @@ const TestsPanel = ({ tests }) => {
               </div>
             </h2>
             <ul style={{ listStyle: 'none', fontSize: 14 }}>
-              {result.assertionResults.map(({ fullName, status, failureMessages }) => {
+              {result.assertionResults.map(({ fullName, status, failureMessages, title }) => {
                 const color = status === 'passed' ? colors.success : colors.error;
                 return (
                   <li key={fullName}>
@@ -118,7 +118,7 @@ const TestsPanel = ({ tests }) => {
                     >
                       <div style={{ display: 'flex', alignItems: 'center' }}>
                         <Indicator color={color} size={10} />
-                        <div>{fullName}</div>
+                        <div>{fullName || title}</div>
                       </div>
                       <div style={{ display: 'flex', alignItems: 'center' }}>
                         <Indicator color={color} size={14} right>


### PR DESCRIPTION
As stated in #9 with create-react-app default `test` command, output uses `title` instead of `fullName` for the test assertions names. Resulting in blank titles in Storybook Jest panel.